### PR TITLE
Use goroutines for each license and add features aggregate expiration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters-settings:
   maligned:
     suggest-new: true
   dupl:
-    threshold: 100
+    threshold: 200
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ groups:
     annotations:
       summary: "Licence Available Status (instance {{ $labels.instance }})"
       description: "Licence fully used \n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+  - alert: LicenseExpiring
+    expr: ((flexlm_feature_expiration_seconds - time()) / 86400) < 14
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: License {{ $labels.app }} expiring soon on {{ $labels.instance }}
+      description: License {{ $labels.app }} on {{ $labels.instance }} has {{ $labels.features }} features ({{ $labels.licenses }} licenses) expiring in {{ $value }} days
 ```
 
 ## Contributing

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -41,6 +41,12 @@ var (
 		[]string{"collector"},
 		nil,
 	)
+	scrapeErrorDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "scrape", "error"),
+		"flexlm_exporter: Whether a license scrape had an error.",
+		[]string{"collector", "name"},
+		nil,
+	)
 )
 
 const (
@@ -113,6 +119,7 @@ func NewFlexlmCollector(filters ...string) (*FlexlmCollector, error) {
 func (n FlexlmCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- scrapeDurationDesc
 	ch <- scrapeSuccessDesc
+	ch <- scrapeErrorDesc
 }
 
 // Collect implements the prometheus.Collector interface.

--- a/collector/lmstat_feature_exp.go
+++ b/collector/lmstat_feature_exp.go
@@ -22,7 +22,8 @@ import (
 )
 
 type lmstatFeatureExpCollector struct {
-	lmstatFeatureExp *prometheus.Desc
+	lmstatFeatureExp     *prometheus.Desc
+	lmstatFeatureAggrExp *prometheus.Desc
 }
 
 func init() {
@@ -40,6 +41,11 @@ func NewLmstatFeatureExpCollector() (Collector, error) {
 			"License feature expiration date in seconds labeled by app, name, index, licenses, vendor, version.",
 			[]string{"app", "name", "index", "licenses", "vendor",
 				"version"}, nil,
+		),
+		lmstatFeatureAggrExp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "feature", "aggregate_expiration_seconds"),
+			"Aggregate by license features expiration day in seconds. Labeled by app, licenses, features.",
+			[]string{"app", "licenses", "features"}, nil,
 		),
 	}, nil
 }

--- a/collector/lmstat_feature_exp.go
+++ b/collector/lmstat_feature_exp.go
@@ -45,7 +45,7 @@ func NewLmstatFeatureExpCollector() (Collector, error) {
 		lmstatFeatureAggrExp: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "feature", "aggregate_expiration_seconds"),
 			"Aggregate by license features expiration day in seconds. Labeled by app, licenses, features.",
-			[]string{"app", "licenses", "features"}, nil,
+			[]string{"app", "index", "licenses", "features"}, nil,
 		),
 	}, nil
 }

--- a/collector/lmstat_feature_exp_linux.go
+++ b/collector/lmstat_feature_exp_linux.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -182,13 +183,19 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 			feature.version)
 	}
 
-	index := 0
+	aggrFeaturesKeys := make([]float64, 0, len(aggrFeaturesExpMap))
 
-	for exp, val := range aggrFeaturesExpMap {
+	for exp := range aggrFeaturesExpMap {
+		aggrFeaturesKeys = append(aggrFeaturesKeys, exp)
+	}
+
+	sort.Float64s(aggrFeaturesKeys)
+
+	for idx, exp := range aggrFeaturesKeys {
+		val := aggrFeaturesExpMap[exp]
 		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureAggrExp,
 			prometheus.GaugeValue, exp,
-			val.app, strconv.Itoa(index), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
-		index++
+			val.app, strconv.Itoa(idx), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
 	}
 
 	return nil

--- a/collector/lmstat_feature_exp_linux.go
+++ b/collector/lmstat_feature_exp_linux.go
@@ -182,10 +182,13 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 			feature.version)
 	}
 
+	index := 0
+
 	for exp, val := range aggrFeaturesExpMap {
 		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureAggrExp,
 			prometheus.GaugeValue, exp,
-			val.app, strconv.Itoa(val.licenses), strconv.Itoa(val.features))
+			val.app, strconv.Itoa(index), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
+		index++
 	}
 
 	return nil

--- a/collector/lmstat_feature_exp_linux.go
+++ b/collector/lmstat_feature_exp_linux.go
@@ -19,8 +19,10 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/mjtrangoni/flexlm_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 )
@@ -85,69 +87,84 @@ func parseLmstatLicenseFeatureExpDate(outStr [][]string) map[int]*featureExp {
 
 // getLmstatFeatureExpDate returns lmstat active and inactive licenses expiration date
 func (c *lmstatFeatureExpCollector) getLmstatFeatureExpDate(ch chan<- prometheus.Metric) error {
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+	for _, licenses := range LicenseConfig.Licenses {
+		wg.Add(1)
+		go func(licenses config.License) {
+			defer wg.Done()
+			err := c.collect(licenses, ch)
+			if err == nil {
+				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat_feature_exp", licenses.Name)
+			} else {
+				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat_feature_exp", licenses.Name)
+			}
+		}(licenses)
+	}
+
+	return nil
+}
+
+func (c *lmstatFeatureExpCollector) collect(licenses config.License, ch chan<- prometheus.Metric) error {
 	var (
 		outBytes []byte
 		err      error
 	)
-
-	for _, licenses := range LicenseConfig.Licenses {
-		// Call lmstat with -i (lmstat -i does not give information from the server,
-		// but only reads the license file)
-		if licenses.LicenseFile != "" {
-			outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-i")
-			if err != nil {
-				continue
-			}
-		} else if licenses.LicenseServer != "" {
-			outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-i")
-			if err != nil {
-				continue
-			}
-		} else {
-			log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
-				licenses.Name)
-			return nil
-		}
-
-		outStr, err := splitOutput(outBytes)
+	// Call lmstat with -i (lmstat -i does not give information from the server,
+	// but only reads the license file)
+	if licenses.LicenseFile != "" {
+		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-i")
 		if err != nil {
-			log.Errorln(err)
 			return err
 		}
-
-		// features
-		var (
-			featuresToExclude = []string{}
-			featuresToInclude = []string{}
-		)
-
-		if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
-			log.Fatalln("%v: can not define `features_to_include` and "+
-				"`features_to_exclude` at the same time", licenses.Name)
-			return nil
-		} else if licenses.FeaturesToExclude != "" {
-			featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
-		} else if licenses.FeaturesToInclude != "" {
-			featuresToInclude = strings.Split(licenses.FeaturesToInclude, ",")
+	} else if licenses.LicenseServer != "" {
+		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-i")
+		if err != nil {
+			return err
 		}
-
-		featuresExp := parseLmstatLicenseFeatureExpDate(outStr)
-
-		for idx, feature := range featuresExp {
-			if contains(featuresToExclude, feature.name) {
-				continue
-			} else if licenses.FeaturesToInclude != "" &&
-				!contains(featuresToInclude, feature.name) {
-				continue
-			}
-
-			ch <- prometheus.MustNewConstMetric(c.lmstatFeatureExp,
-				prometheus.GaugeValue, feature.expires,
-				licenses.Name, feature.name, strconv.Itoa(idx),
-				feature.licenses, feature.vendor,
-				feature.version)
-		}
+	} else {
+		log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
+			licenses.Name)
+		return nil
 	}
 
+	outStr, err := splitOutput(outBytes)
+	if err != nil {
+		log.Errorln(err)
+		return err
+	}
+
+	// features
+	var (
+		featuresToExclude = []string{}
+		featuresToInclude = []string{}
+	)
+
+	if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
+		log.Fatalln("%v: can not define `features_to_include` and "+
+			"`features_to_exclude` at the same time", licenses.Name)
+		return nil
+	} else if licenses.FeaturesToExclude != "" {
+		featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
+	} else if licenses.FeaturesToInclude != "" {
+		featuresToInclude = strings.Split(licenses.FeaturesToInclude, ",")
+	}
+
+	featuresExp := parseLmstatLicenseFeatureExpDate(outStr)
+
+	for idx, feature := range featuresExp {
+		if contains(featuresToExclude, feature.name) {
+			continue
+		} else if licenses.FeaturesToInclude != "" &&
+			!contains(featuresToInclude, feature.name) {
+			continue
+		}
+
+		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureExp,
+			prometheus.GaugeValue, feature.expires,
+			licenses.Name, feature.name, strconv.Itoa(idx),
+			feature.licenses, feature.vendor,
+			feature.version)
+	}
 	return nil
 }

--- a/collector/lmstat_feature_exp_windows.go
+++ b/collector/lmstat_feature_exp_windows.go
@@ -133,6 +133,7 @@ func (c *lmstatFeatureExpCollector) collect(licenses config.License, ch chan<- p
 	}
 
 	featuresExp := parseLmstatLicenseFeatureExpDate(outStr)
+	aggrFeaturesExpMap := make(map[float64]*aggrFeaturesExp)
 
 	for idx, feature := range featuresExp {
 		if contains(featuresToExclude, feature.name) {
@@ -142,11 +143,31 @@ func (c *lmstatFeatureExpCollector) collect(licenses config.License, ch chan<- p
 			continue
 		}
 
+		licenseCount, _ := strconv.Atoi(feature.licenses)
+		if val, ok := aggrFeaturesExpMap[feature.expires]; ok {
+			//expFeat := val
+			val.features++
+			val.licenses = val.licenses + licenseCount
+			//expFeaturesMap[feature.expires] = expFeat
+		} else {
+			aggrFeaturesExpMap[feature.expires] = &aggrFeaturesExp{
+				app:      licenses.Name,
+				features: 1,
+				licenses: licenseCount,
+			}
+		}
+
 		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureExp,
 			prometheus.GaugeValue, feature.expires,
 			licenses.Name, feature.name, strconv.Itoa(idx),
 			feature.licenses, feature.vendor,
 			feature.version)
+	}
+
+	for exp, val := range aggrFeaturesExpMap {
+		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureAggrExp,
+			prometheus.GaugeValue, exp,
+			val.app, strconv.Itoa(val.licenses), strconv.Itoa(val.features))
 	}
 	return nil
 }

--- a/collector/lmstat_feature_exp_windows.go
+++ b/collector/lmstat_feature_exp_windows.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -163,13 +164,19 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 			feature.version)
 	}
 
-	index := 0
+	aggrFeaturesKeys := make([]float64, 0, len(aggrFeaturesExpMap))
 
-	for exp, val := range aggrFeaturesExpMap {
+	for exp := range aggrFeaturesExpMap {
+		aggrFeaturesKeys = append(aggrFeaturesKeys, exp)
+	}
+
+	sort.Float64s(aggrFeaturesKeys)
+
+	for idx, exp := range aggrFeaturesKeys {
+		val := aggrFeaturesExpMap[exp]
 		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureAggrExp,
 			prometheus.GaugeValue, exp,
-			val.app, strconv.Itoa(index), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
-		index++
+			val.app, strconv.Itoa(idx), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
 	}
 	return nil
 }

--- a/collector/lmstat_feature_exp_windows.go
+++ b/collector/lmstat_feature_exp_windows.go
@@ -163,10 +163,13 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 			feature.version)
 	}
 
+	index := 0
+
 	for exp, val := range aggrFeaturesExpMap {
 		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureAggrExp,
 			prometheus.GaugeValue, exp,
-			val.app, strconv.Itoa(val.licenses), strconv.Itoa(val.features))
+			val.app, strconv.Itoa(index), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
+		index++
 	}
 	return nil
 }

--- a/collector/lmstat_linux.go
+++ b/collector/lmstat_linux.go
@@ -264,22 +264,25 @@ func (c *lmstatCollector) getLmstatInfo(ch chan<- prometheus.Metric) error {
 func (c *lmstatCollector) getLmstatLicensesInfo(ch chan<- prometheus.Metric) error {
 	wg := &sync.WaitGroup{}
 	defer wg.Wait()
+
 	for _, licenses := range LicenseConfig.Licenses {
-		wg.Add(1)
+		wg.Add(lenghtOne)
+
 		go func(licenses config.License) {
 			defer wg.Done()
-			err := c.collect(licenses, ch)
-			if err == nil {
+
+			if err := c.collect(&licenses, ch); err == nil {
 				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat", licenses.Name)
 			} else {
 				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat", licenses.Name)
 			}
 		}(licenses)
 	}
+
 	return nil
 }
 
-func (c *lmstatCollector) collect(licenses config.License, ch chan<- prometheus.Metric) error {
+func (c *lmstatCollector) collect(licenses *config.License, ch chan<- prometheus.Metric) error {
 	var (
 		outBytes []byte
 		err      error

--- a/collector/lmstat_linux.go
+++ b/collector/lmstat_linux.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
+	"github.com/mjtrangoni/flexlm_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 )
@@ -260,100 +262,116 @@ func (c *lmstatCollector) getLmstatInfo(ch chan<- prometheus.Metric) error {
 
 // getLmstatLicensesInfo returns lmstat active licenses information
 func (c *lmstatCollector) getLmstatLicensesInfo(ch chan<- prometheus.Metric) error {
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+	for _, licenses := range LicenseConfig.Licenses {
+		wg.Add(1)
+		go func(licenses config.License) {
+			defer wg.Done()
+			err := c.collect(licenses, ch)
+			if err == nil {
+				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat", licenses.Name)
+			} else {
+				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat", licenses.Name)
+			}
+		}(licenses)
+	}
+	return nil
+}
+
+func (c *lmstatCollector) collect(licenses config.License, ch chan<- prometheus.Metric) error {
 	var (
 		outBytes []byte
 		err      error
 	)
 
-	for _, licenses := range LicenseConfig.Licenses {
-		// Call lmstat with -a (display everything)
-		if licenses.LicenseFile != "" {
-			outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-a")
-			if err != nil {
-				continue
-			}
-		} else if licenses.LicenseServer != "" {
-			outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-a")
-			if err != nil {
-				continue
-			}
-		} else {
-			log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
-				licenses.Name)
-			return nil
-		}
-
-		outStr, err := splitOutput(outBytes)
+	// Call lmstat with -a (display everything)
+	if licenses.LicenseFile != "" {
+		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-a")
 		if err != nil {
-			log.Errorln(err)
 			return err
 		}
+	} else if licenses.LicenseServer != "" {
+		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-a")
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
+			licenses.Name)
+		return nil
+	}
 
-		servers := parseLmstatLicenseInfoServer(outStr)
-		for _, info := range servers {
-			if info.status {
-				ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
-					prometheus.GaugeValue, 1.0, licenses.Name, info.fqdn,
-					strconv.FormatBool(info.master), info.port, info.version)
-			} else {
-				ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
-					prometheus.GaugeValue, 0, licenses.Name, info.fqdn,
-					strconv.FormatBool(info.master), info.port, info.version)
+	outStr, err := splitOutput(outBytes)
+	if err != nil {
+		log.Errorln(err)
+		return err
+	}
+
+	servers := parseLmstatLicenseInfoServer(outStr)
+	for _, info := range servers {
+		if info.status {
+			ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
+				prometheus.GaugeValue, 1.0, licenses.Name, info.fqdn,
+				strconv.FormatBool(info.master), info.port, info.version)
+		} else {
+			ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
+				prometheus.GaugeValue, 0, licenses.Name, info.fqdn,
+				strconv.FormatBool(info.master), info.port, info.version)
+		}
+	}
+
+	vendors := parseLmstatLicenseInfoVendor(outStr)
+	for name, info := range vendors {
+		if info.status {
+			ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
+				prometheus.GaugeValue, 1.0, licenses.Name, name,
+				info.version)
+		} else {
+			ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
+				prometheus.GaugeValue, 0, licenses.Name, name, info.version)
+		}
+	}
+	// features
+	var (
+		featuresToExclude = []string{}
+		featuresToInclude = []string{}
+	)
+
+	if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
+		log.Fatalln("%v: can not define `features_to_include` and "+
+			"`features_to_exclude` at the same time", licenses.Name)
+		return nil
+	} else if licenses.FeaturesToExclude != "" {
+		featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
+	} else if licenses.FeaturesToInclude != "" {
+		featuresToInclude = strings.Split(licenses.FeaturesToInclude, ",")
+	}
+
+	features, licUsersByFeature, reservGroupByFeature := parseLmstatLicenseInfoFeature(outStr)
+	for name, info := range features {
+		if contains(featuresToExclude, name) {
+			continue
+		} else if licenses.FeaturesToInclude != "" &&
+			!contains(featuresToInclude, name) {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureUsed,
+			prometheus.GaugeValue, info.used, licenses.Name, name)
+		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureIssued,
+			prometheus.GaugeValue, info.issued, licenses.Name, name)
+		if licenses.MonitorUsers && (licUsersByFeature[name] != nil) {
+			for username, licused := range licUsersByFeature[name] {
+				ch <- prometheus.MustNewConstMetric(
+					c.lmstatFeatureUsedUsers, prometheus.GaugeValue,
+					licused, licenses.Name, name, username)
 			}
 		}
-
-		vendors := parseLmstatLicenseInfoVendor(outStr)
-		for name, info := range vendors {
-			if info.status {
-				ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
-					prometheus.GaugeValue, 1.0, licenses.Name, name,
-					info.version)
-			} else {
-				ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
-					prometheus.GaugeValue, 0, licenses.Name, name, info.version)
-			}
-		}
-		// features
-		var (
-			featuresToExclude = []string{}
-			featuresToInclude = []string{}
-		)
-
-		if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
-			log.Fatalln("%v: can not define `features_to_include` and "+
-				"`features_to_exclude` at the same time", licenses.Name)
-			return nil
-		} else if licenses.FeaturesToExclude != "" {
-			featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
-		} else if licenses.FeaturesToInclude != "" {
-			featuresToInclude = strings.Split(licenses.FeaturesToInclude, ",")
-		}
-
-		features, licUsersByFeature, reservGroupByFeature := parseLmstatLicenseInfoFeature(outStr)
-		for name, info := range features {
-			if contains(featuresToExclude, name) {
-				continue
-			} else if licenses.FeaturesToInclude != "" &&
-				!contains(featuresToInclude, name) {
-				continue
-			}
-			ch <- prometheus.MustNewConstMetric(c.lmstatFeatureUsed,
-				prometheus.GaugeValue, info.used, licenses.Name, name)
-			ch <- prometheus.MustNewConstMetric(c.lmstatFeatureIssued,
-				prometheus.GaugeValue, info.issued, licenses.Name, name)
-			if licenses.MonitorUsers && (licUsersByFeature[name] != nil) {
-				for username, licused := range licUsersByFeature[name] {
-					ch <- prometheus.MustNewConstMetric(
-						c.lmstatFeatureUsedUsers, prometheus.GaugeValue,
-						licused, licenses.Name, name, username)
-				}
-			}
-			if licenses.MonitorReservations && (reservGroupByFeature[name] != nil) {
-				for group, licreserv := range reservGroupByFeature[name] {
-					ch <- prometheus.MustNewConstMetric(
-						c.lmstatFeatureReservGroups, prometheus.GaugeValue,
-						licreserv, licenses.Name, name, group)
-				}
+		if licenses.MonitorReservations && (reservGroupByFeature[name] != nil) {
+			for group, licreserv := range reservGroupByFeature[name] {
+				ch <- prometheus.MustNewConstMetric(
+					c.lmstatFeatureReservGroups, prometheus.GaugeValue,
+					licreserv, licenses.Name, name, group)
 			}
 		}
 	}

--- a/collector/lmstat_windows.go
+++ b/collector/lmstat_windows.go
@@ -236,93 +236,109 @@ func (c *lmstatCollector) getLmstatInfo(ch chan<- prometheus.Metric) error {
 
 // getLmstatLicensesInfo returns lmstat active licenses information
 func (c *lmstatCollector) getLmstatLicensesInfo(ch chan<- prometheus.Metric) error {
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+	for _, licenses := range LicenseConfig.Licenses {
+		wg.Add(1)
+		go func(licenses config.License) {
+			defer wg.Done()
+			err := c.collect(licenses, ch)
+			if err == nil {
+				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat", licenses.Name)
+			} else {
+				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat", licenses.Name)
+			}
+		}(licenses)
+	}
+	return nil
+}
+
+func (c *lmstatCollector) collect(licenses config.License, ch chan<- prometheus.Metric) error {
 	var outBytes []byte
 	var err error
 
-	for _, licenses := range LicenseConfig.Licenses {
-		// Call lmstat with -a (display everything)
-		if licenses.LicenseFile != "" {
-			outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-a")
-			if err != nil {
-				continue
-			}
-		} else if licenses.LicenseServer != "" {
-			outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-a")
-			if err != nil {
-				continue
-			}
-		} else {
-			log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
-				licenses.Name)
-			return nil
-		}
-
-		outStr, err := splitOutput(outBytes)
+	// Call lmstat with -a (display everything)
+	if licenses.LicenseFile != "" {
+		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-a")
 		if err != nil {
-			log.Errorln(err)
 			return err
 		}
+	} else if licenses.LicenseServer != "" {
+		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-a")
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
+			licenses.Name)
+		return nil
+	}
 
-		servers := parseLmstatLicenseInfoServer(outStr)
-		for _, info := range servers {
-			if info.status {
-				ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
-					prometheus.GaugeValue, 1.0, licenses.Name, info.fqdn,
-					strconv.FormatBool(info.master), info.port, info.version)
-			} else {
-				ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
-					prometheus.GaugeValue, 0, licenses.Name, info.fqdn,
-					strconv.FormatBool(info.master), info.port, info.version)
+	outStr, err := splitOutput(outBytes)
+	if err != nil {
+		log.Errorln(err)
+		return err
+	}
+
+	servers := parseLmstatLicenseInfoServer(outStr)
+	for _, info := range servers {
+		if info.status {
+			ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
+				prometheus.GaugeValue, 1.0, licenses.Name, info.fqdn,
+				strconv.FormatBool(info.master), info.port, info.version)
+		} else {
+			ch <- prometheus.MustNewConstMetric(c.lmstatServerStatus,
+				prometheus.GaugeValue, 0, licenses.Name, info.fqdn,
+				strconv.FormatBool(info.master), info.port, info.version)
+		}
+	}
+	vendors := parseLmstatLicenseInfoVendor(outStr)
+	for name, info := range vendors {
+		if info.status {
+			ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
+				prometheus.GaugeValue, 1.0, licenses.Name, name,
+				info.version)
+		} else {
+			ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
+				prometheus.GaugeValue, 0, licenses.Name, name, info.version)
+		}
+	}
+	// features
+	var featuresToExclude = []string{}
+	var featuresToInclude = []string{}
+	if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
+		log.Fatalln("%v: can not define `features_to_include` and "+
+			"`features_to_exclude` at the same time", licenses.Name)
+		return nil
+	} else if licenses.FeaturesToExclude != "" {
+		featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
+	} else if licenses.FeaturesToInclude != "" {
+		featuresToInclude = strings.Split(licenses.FeaturesToInclude, ",")
+	}
+	features, licUsersByFeature, reservGroupByFeature := parseLmstatLicenseInfoFeature(outStr)
+	for name, info := range features {
+		if contains(featuresToExclude, name) {
+			continue
+		} else if licenses.FeaturesToInclude != "" &&
+			!contains(featuresToInclude, name) {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureUsed,
+			prometheus.GaugeValue, info.used, licenses.Name, name)
+		ch <- prometheus.MustNewConstMetric(c.lmstatFeatureIssued,
+			prometheus.GaugeValue, info.issued, licenses.Name, name)
+		if licenses.MonitorUsers && (licUsersByFeature[name] != nil) {
+			for username, licused := range licUsersByFeature[name] {
+				ch <- prometheus.MustNewConstMetric(
+					c.lmstatFeatureUsedUsers, prometheus.GaugeValue,
+					licused, licenses.Name, name, username)
 			}
 		}
-		vendors := parseLmstatLicenseInfoVendor(outStr)
-		for name, info := range vendors {
-			if info.status {
-				ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
-					prometheus.GaugeValue, 1.0, licenses.Name, name,
-					info.version)
-			} else {
-				ch <- prometheus.MustNewConstMetric(c.lmstatVendorStatus,
-					prometheus.GaugeValue, 0, licenses.Name, name, info.version)
-			}
-		}
-		// features
-		var featuresToExclude = []string{}
-		var featuresToInclude = []string{}
-		if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
-			log.Fatalln("%v: can not define `features_to_include` and "+
-				"`features_to_exclude` at the same time", licenses.Name)
-			return nil
-		} else if licenses.FeaturesToExclude != "" {
-			featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
-		} else if licenses.FeaturesToInclude != "" {
-			featuresToInclude = strings.Split(licenses.FeaturesToInclude, ",")
-		}
-		features, licUsersByFeature, reservGroupByFeature := parseLmstatLicenseInfoFeature(outStr)
-		for name, info := range features {
-			if contains(featuresToExclude, name) {
-				continue
-			} else if licenses.FeaturesToInclude != "" &&
-				!contains(featuresToInclude, name) {
-				continue
-			}
-			ch <- prometheus.MustNewConstMetric(c.lmstatFeatureUsed,
-				prometheus.GaugeValue, info.used, licenses.Name, name)
-			ch <- prometheus.MustNewConstMetric(c.lmstatFeatureIssued,
-				prometheus.GaugeValue, info.issued, licenses.Name, name)
-			if licenses.MonitorUsers && (licUsersByFeature[name] != nil) {
-				for username, licused := range licUsersByFeature[name] {
-					ch <- prometheus.MustNewConstMetric(
-						c.lmstatFeatureUsedUsers, prometheus.GaugeValue,
-						licused, licenses.Name, name, username)
-				}
-			}
-			if licenses.MonitorReservations && (reservGroupByFeature[name] != nil) {
-				for group, licreserv := range reservGroupByFeature[name] {
-					ch <- prometheus.MustNewConstMetric(
-						c.lmstatFeatureReservGroups, prometheus.GaugeValue,
-						licreserv, licenses.Name, name, group)
-				}
+		if licenses.MonitorReservations && (reservGroupByFeature[name] != nil) {
+			for group, licreserv := range reservGroupByFeature[name] {
+				ch <- prometheus.MustNewConstMetric(
+					c.lmstatFeatureReservGroups, prometheus.GaugeValue,
+					licreserv, licenses.Name, name, group)
 			}
 		}
 	}

--- a/collector/lmstat_windows.go
+++ b/collector/lmstat_windows.go
@@ -239,21 +239,23 @@ func (c *lmstatCollector) getLmstatLicensesInfo(ch chan<- prometheus.Metric) err
 	wg := &sync.WaitGroup{}
 	defer wg.Wait()
 	for _, licenses := range LicenseConfig.Licenses {
-		wg.Add(1)
+		wg.Add(lenghtOne)
+
 		go func(licenses config.License) {
 			defer wg.Done()
-			err := c.collect(licenses, ch)
-			if err == nil {
+
+			if err := c.collect(&licenses, ch); err == nil {
 				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat", licenses.Name)
 			} else {
 				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat", licenses.Name)
 			}
 		}(licenses)
 	}
+
 	return nil
 }
 
-func (c *lmstatCollector) collect(licenses config.License, ch chan<- prometheus.Metric) error {
+func (c *lmstatCollector) collect(licenses *config.License, ch chan<- prometheus.Metric) error {
 	var outBytes []byte
 	var err error
 

--- a/collector/structs.go
+++ b/collector/structs.go
@@ -45,3 +45,9 @@ type featureExp struct {
 	vendor   string
 	version  string
 }
+
+type aggrFeaturesExp struct {
+	app      string
+	features int
+	licenses int
+}


### PR DESCRIPTION
Main change was to execute each license collection in parallel using goroutines. Also add metric to indicate if failures occurred during collection.

Added metric `flexlm_feature_aggregate_expiration_seconds` that groups features for a license by expiration times. I use this in an alert so that if a license has 25 features expiring soon we only get 1 alert and not 25 alerts.

The diff is not as big if you use something like `git diff -w` to remove whitespace changes.

Alert we are using:

```
  rules:
  - record: flexlm_feature_aggregate_expiration_days
    expr: (flexlm_feature_aggregate_expiration_seconds - time()) / 86400
  - alert: LicenseExpiring
    expr: flexlm_feature_aggregate_expiration_days < 14
    for: 5m
    labels:
      notify: daily
      alertgroup: licenses
      severity: warning
      alsonotify: license-admins
    annotations:
      title: License {{ $labels.license }} expiring soon on {{ $labels.host }}
      description: License {{ $labels.license }} on {{ $labels.host }} has {{ $labels.features }} features ({{ $labels.licenses }} licenses) expiring in {{ $value }} days
```