### PR TITLE
Allow flexlm expiration metrics to be cached if lmutil fails

### DIFF
--- a/collector/lmstat_feature_exp.go
+++ b/collector/lmstat_feature_exp.go
@@ -17,8 +17,19 @@ package collector
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	expUseCache = kingpin.Flag("collector.lmstat_feature_exp.use-cache",
+		"Use cached metrics if lmutil execution fails").Default("false").Bool()
+	lmstatExpCache        = map[string][]byte{}
+	lmstatExpCacheMutex   = sync.RWMutex{}
+	expPreParseCache      = map[string][][]string{}
+	expPreParseCacheMutex = sync.RWMutex{}
 )
 
 type lmstatFeatureExpCollector struct {

--- a/collector/lmstat_feature_exp_linux.go
+++ b/collector/lmstat_feature_exp_linux.go
@@ -113,20 +113,17 @@ func (c *lmstatFeatureExpCollector) getLmstatFeatureExpDate(ch chan<- prometheus
 		go func(licenses config.License) {
 			defer wg.Done()
 
-			if err := c.collect(&licenses, ch); err == nil {
-				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat_feature_exp", licenses.Name)
-			} else {
-				ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat_feature_exp", licenses.Name)
-			}
+			c.collect(&licenses, ch)
 		}(licenses)
 	}
 
 	return nil
 }
 
-func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- prometheus.Metric) error {
+func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- prometheus.Metric) {
 	var (
 		outBytes []byte
+		outStr   [][]string
 		err      error
 	)
 	// Call lmstat with -i (lmstat -i does not give information from the server,
@@ -134,23 +131,45 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 	if licenses.LicenseFile != "" {
 		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseFile, "-i")
 		if err != nil {
-			return err
+			if *expUseCache {
+				lmstatExpCacheMutex.RLock()
+				outBytes = lmstatExpCache[licenses.Name]
+				lmstatExpCacheMutex.RUnlock()
+			}
 		}
 	} else if licenses.LicenseServer != "" {
 		outBytes, err = lmutilOutput("lmstat", "-c", licenses.LicenseServer, "-i")
 		if err != nil {
-			return err
+			if *expUseCache {
+				lmstatExpCacheMutex.RLock()
+				outBytes = lmstatExpCache[licenses.Name]
+				lmstatExpCacheMutex.RUnlock()
+			}
 		}
 	} else {
 		log.Fatalf("couldn`t find `license_file` or `license_server` for %v",
 			licenses.Name)
-		return nil
+		return
 	}
 
-	outStr, err := splitOutput(outBytes)
+	if *expUseCache && err == nil {
+		lmstatExpCacheMutex.Lock()
+		lmstatExpCache[licenses.Name] = outBytes
+		lmstatExpCacheMutex.Unlock()
+	}
+
+	outStr, err = splitOutput(outBytes)
 	if err != nil {
 		log.Errorln(err)
-		return err
+		if *expUseCache {
+			expPreParseCacheMutex.RLock()
+			outStr = expPreParseCache[licenses.Name]
+			expPreParseCacheMutex.RUnlock()
+		}
+	} else {
+		expPreParseCacheMutex.Lock()
+		expPreParseCache[licenses.Name] = outStr
+		expPreParseCacheMutex.Unlock()
 	}
 
 	// features
@@ -162,7 +181,7 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 	if licenses.FeaturesToExclude != "" && licenses.FeaturesToInclude != "" {
 		log.Fatalln("%v: can not define `features_to_include` and "+
 			"`features_to_exclude` at the same time", licenses.Name)
-		return nil
+		return
 	} else if licenses.FeaturesToExclude != "" {
 		featuresToExclude = strings.Split(licenses.FeaturesToExclude, ",")
 	} else if licenses.FeaturesToInclude != "" {
@@ -214,5 +233,9 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 			val.app, strconv.Itoa(idx), strconv.Itoa(val.licenses), strconv.Itoa(val.features))
 	}
 
-	return nil
+	if err == nil {
+		ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 0, "lmstat_feature_exp", licenses.Name)
+	} else {
+		ch <- prometheus.MustNewConstMetric(scrapeErrorDesc, prometheus.GaugeValue, 1, "lmstat_feature_exp", licenses.Name)
+	}
 }


### PR DESCRIPTION
We had instances where lmutil would fail intermittently which for alerts would cause false resolves to go out when no data is present.  This change adds a opt-in ability to cache lmutil data so that any failures of lmutil will use cached data.  Without `--collector.lmstat_feature_exp.use-cache` there is no behavior change.