### PR TITLE
add version to output of "flexlm_feature_used_users"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ licenses:
     features_to_exclude: feature1,feature2
     monitor_users: True
     monitor_reservations: True
+    monitor_versions: False
   - name: app2
     license_server: 28000@host1,28000@host2,28000@host3
     features_to_include: feature5,feature30
     monitor_users: True
     monitor_reservations: True
+    monitor_versions: False
 ```
 
 Notes:

--- a/collector/lmstat.go
+++ b/collector/lmstat.go
@@ -23,13 +23,14 @@ import (
 )
 
 type lmstatCollector struct {
-	lmstatInfo                *prometheus.Desc
-	lmstatServerStatus        *prometheus.Desc
-	lmstatVendorStatus        *prometheus.Desc
-	lmstatFeatureUsed         *prometheus.Desc
-	lmstatFeatureUsedUsers    *prometheus.Desc
-	lmstatFeatureReservGroups *prometheus.Desc
-	lmstatFeatureIssued       *prometheus.Desc
+	lmstatInfo                     *prometheus.Desc
+	lmstatServerStatus             *prometheus.Desc
+	lmstatVendorStatus             *prometheus.Desc
+	lmstatFeatureUsed              *prometheus.Desc
+	lmstatFeatureUsedUsers         *prometheus.Desc
+	lmstatFeatureUsedUsersVersions *prometheus.Desc
+	lmstatFeatureReservGroups      *prometheus.Desc
+	lmstatFeatureIssued            *prometheus.Desc
 }
 
 // LicenseConfig is going to be read once in main, and then used here.
@@ -70,6 +71,11 @@ func NewLmstatCollector() (Collector, error) {
 			prometheus.BuildFQName(namespace, "feature", "used_users"),
 			"License feature used by user labeled by app, feature name and "+
 				"username of the license.", []string{"app", "name", "user"}, nil,
+		),
+		lmstatFeatureUsedUsersVersions: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "feature", "used_users"),
+			"License feature used by user labeled by app, feature name, "+
+				"username of the license and version.", []string{"app", "name", "user", "version"}, nil,
 		),
 		lmstatFeatureReservGroups: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "feature", "reserved_groups"),

--- a/collector/lmstat_linux_test.go
+++ b/collector/lmstat_linux_test.go
@@ -228,20 +228,20 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 
 	for username, licused := range licUsersByFeature["feature34"] {
 		if username == "user1" {
-			if licused != licUsed16 {
+			if licused.num != licUsed16 {
 				t.Fatalf("Unexpected values for feature34[%s]: %v!=16",
-					username, licused)
+					username, licused.num)
 			}
 		} else if username == "user11" {
 			foundUser11 = true
-			if licused != licUsed26 {
+			if licused.num != licUsed26 {
 				t.Fatalf("Unexpected values for feature34[%s]: %v!=26",
-					username, licused)
+					username, licused.num)
 			}
 		} else if username == "user17" {
-			if licused != licUsed12 {
+			if licused.num != licUsed12 {
 				t.Fatalf("Unexpected values for feature34[%s]: %v!=12",
-					username, licused)
+					username, licused.num)
 			}
 		}
 	}
@@ -254,20 +254,20 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 
 	for username, licused := range licUsersByFeature["feature31"] {
 		if username == "user33" {
-			if licused != licUsed16 {
+			if licused.num != licUsed16 {
 				t.Fatalf("Unexpected values for feature31[%s]: %v!=16",
-					username, licused)
+					username, licused.num)
 			}
 		} else if username == "cmfy211" {
 			foundCmfy211 = true
-			if licused != licUsed1 {
+			if licused.num != licUsed1 {
 				t.Fatalf("Unexpected values for feature31[%s]: %v!=1",
-					username, licused)
+					username, licused.num)
 			}
 		} else if username == "cmfy212" {
-			if licused != licUsed16 {
+			if licused.num != licUsed16 {
 				t.Fatalf("Unexpected values for feature31[%s]: %v!=16",
-					username, licused)
+					username, licused.num)
 			}
 		}
 	}
@@ -284,9 +284,9 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 
 	for username, licused := range licUsersByFeature["feature100"] {
 		if username == "user13" {
-			if licused != licUsed1 {
+			if licused.num != licUsed1 {
 				t.Fatalf("Unexpected values for feature1[%s]: %v!=1",
-					username, licused)
+					username, licused.num)
 			}
 		} else if username == "Administrator" {
 			// There is 2 users, and this should always enter here.

--- a/collector/regexp.go
+++ b/collector/regexp.go
@@ -17,11 +17,11 @@ var (
 		`^Users of (?P<name>.*):\s+\(Total of (?P<issued>\d+) \w+ issued\;\s+` +
 			`Total of (?P<used>\d+) \w+ in use\)$`)
 	lmutilLicenseFeatureUsageUserRegex = regexp.MustCompile(
-		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ [[:print:]]+ ?\(v[\w\.]+\) \([\w\-\.]+\/\d+ ` +
+		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ [[:print:]]+ (?P<ver>\(v[\w\.]+\)) \([\w\-\.]+\/\d+ ` +
 			`\d+\)\, start \w+ \d+\/\d+ \d+\:\d+(\,\s(?P<licenses>\d+)\s\w+|)` +
 			`(\s+\(linger\:\s\d+\s\/\s\d+\))?$`)
 	lmutilLicenseFeatureUsageUser2Regex = regexp.MustCompile(
-		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ ?\(v[\w\.]+\) \([\w\-\.]+\/\d+ ` +
+		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ (?P<ver>\(v[\w\.]+\)) \([\w\-\.]+\/\d+ ` +
 			`\d+\)\, start \w+ \d+\/\d+ \d+\:\d+(\,\s(?P<licenses>\d+)\s\w+|)` +
 			`(\s+\(linger\:\s\d+\s\/\s\d+\))?$`)
 	lmutilLicenseFeatureGroupReservRegex = regexp.MustCompile(

--- a/collector/structs.go
+++ b/collector/structs.go
@@ -38,6 +38,11 @@ type feature struct {
 	used   float64
 }
 
+type featureUserUsed struct {
+	num     float64
+	version string
+}
+
 type featureExp struct {
 	name     string
 	expires  float64

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type License struct {
 	FeaturesToInclude   string `yaml:"features_to_include,omitempty"`
 	MonitorUsers        bool   `yaml:"monitor_users"`
 	MonitorReservations bool   `yaml:"monitor_reservations"`
+	MonitorVersions     bool   `yaml:"monitor_versions,omitempty"`
 }
 
 // Configuration type for all licenses.


### PR DESCRIPTION
Hey @mjtrangoni,

like I mentioned in issue #48 I added now a version field to `flexlm_feature_used_users` .
It is possible to enable this with a flag, but the function is disabled by default. When enabled, the new output looks like this:
`flexlm_feature_used_users{app="matlab",name="MATLAB",user="username",version="(v43)"} 3`

I also extended the go tests.

Let me know what you think :)