### PR TITLE
Add support for go1.18. Deprecate 1.16 from testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: circleci/golang:1.17
+    - image: circleci/golang:1.18
     parameters:
       working_dir:
         type: string
@@ -40,7 +40,7 @@ jobs:
           name: Install Docker client
           command: |
             set -x
-            VER="20.10.8"
+            VER="20.10.14"
             curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
             tar -xz -C /tmp -f /tmp/docker-$VER.tgz
             ls -la /tmp/docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ["tip", 1.16.x, 1.17.x]
+        go-version: ["tip", 1.17.x, 1.18.x]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-go@v2
@@ -34,7 +34,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install goveralls

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,12 +82,12 @@ issues:
      - text: "consider giving a name to these results"
        linters:
          - gocritic
-     - text: "Subprocess launched with function call as argument or cmd arguments"
+     - text: "Subprocess launched with a potential tainted input or cmd arguments"
        linters:
          - gosec
      - text: "if statements should only be cuddled with assignments"
        linters:
          - wsl
-     - text: "Error return value of `` is not checked"
+     - text: "Error return value of"
        linters:
          errcheck

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here, .github/workflows/build.yml and
-    # .circle/config.yml should also be updated.
-    version: 1.17
+    # .circleci/config.yml should also be updated.
+    version: 1.18
     cgo: false
 repository:
     path: github.com/mjtrangoni/flexlm_exporter

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO                      ?= GO111MODULE=on go
 GOPATH                  := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU                   ?= $(GOPATH)/bin/promu
 GOLINTER                ?= $(GOPATH)/bin/golangci-lint
-GO_VERSION              ?= 1.17
+GO_VERSION              ?= 1.18
 pkgs                    = $(shell $(GO) list ./... | grep -v /vendor/)
 TARGET                  ?= flexlm_exporter
 DOCKER_IMAGE_NAME       ?= mjtrangoni/flexlm_exporter
@@ -69,7 +69,7 @@ docker:
 $(GOPATH)/bin/promu promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
-		$(GO) get github.com/prometheus/promu
+		$(GO) install github.com/prometheus/promu@v0.13.0
 
 .PHONY: tarball
 tarball: promu
@@ -85,4 +85,4 @@ crossbuild: promu
 $(GOPATH)/bin/golangci-lint lint:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
-		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2

--- a/collector/lmstat_feature_exp_linux.go
+++ b/collector/lmstat_feature_exp_linux.go
@@ -27,6 +27,8 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/mjtrangoni/flexlm_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -79,7 +81,7 @@ func parseLmstatLicenseFeatureExpDate(outStr [][]string, logger log.Logger) map[
 
 			expireDate, err := time.Parse("02-Jan-2006",
 				fmt.Sprintf("%s-%s-%s", day,
-					strings.Title(month), year))
+					cases.Title(language.English).String(month), year))
 			if err != nil {
 				level.Error(logger).Log("could not convert to date:", err)
 			}

--- a/collector/lmstat_feature_exp_linux_test.go
+++ b/collector/lmstat_feature_exp_linux_test.go
@@ -15,8 +15,8 @@
 package collector
 
 import (
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -33,7 +33,7 @@ const (
 func TestParseLmstatLicenseFeatureExpDate1(t *testing.T) {
 	t.Parallel()
 
-	dataByte, err := ioutil.ReadFile(testParseLmstatLicenseFeatureExpDate1)
+	dataByte, err := os.ReadFile(testParseLmstatLicenseFeatureExpDate1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestParseLmstatLicenseFeatureExpDate1(t *testing.T) {
 func TestParseLmstatLicenseFeatureExpDate2(t *testing.T) {
 	t.Parallel()
 
-	dataByte, err := ioutil.ReadFile(testParseLmstatLicenseFeatureExpDate2)
+	dataByte, err := os.ReadFile(testParseLmstatLicenseFeatureExpDate2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/collector/lmstat_linux_test.go
+++ b/collector/lmstat_linux_test.go
@@ -15,7 +15,7 @@
 package collector
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -28,7 +28,7 @@ const (
 	testParseLmstatVersionOld   = "fixtures/lmstat_old.txt"
 	testParseLmstatLicenseInfo1 = "fixtures/lmstat_app1.txt"
 	testParseLmstatServerDown   = "fixtures/lmstat_server_down.txt"
-	testParseLmstatServerUpWin  = "fixtures/lmstat_server_up_win.txt"
+	testParseLmstatServerUp     = "fixtures/lmstat_server_up_win.txt"
 )
 
 func TestContains(t *testing.T) {
@@ -48,7 +48,7 @@ func TestContains(t *testing.T) {
 func TestParseLmstatVersion(t *testing.T) {
 	t.Parallel()
 
-	dataByte, err := ioutil.ReadFile(testParseLmstatVersionNew)
+	dataByte, err := os.ReadFile(testParseLmstatVersionNew)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestParseLmstatVersion(t *testing.T) {
 		t.Fatalf("Unexpected values %s, %s, %s != x64_lsb, 188735, v11.14.0.1", lmstatInfo.arch, lmstatInfo.build, lmstatInfo.version)
 	}
 
-	dataByte, err = ioutil.ReadFile(testParseLmstatVersionOld)
+	dataByte, err = os.ReadFile(testParseLmstatVersionOld)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestParseLmstatLicenseInfoServer(t *testing.T) {
 
 	t.Parallel()
 
-	dataByte, err = ioutil.ReadFile(testParseLmstatLicenseInfo1)
+	dataByte, err = os.ReadFile(testParseLmstatLicenseInfo1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestParseLmstatLicenseInfoServer(t *testing.T) {
 		}
 	}
 
-	dataByte, err = ioutil.ReadFile(testParseLmstatServerDown)
+	dataByte, err = os.ReadFile(testParseLmstatServerDown)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestParseLmstatLicenseInfoServer(t *testing.T) {
 		}
 	}
 
-	dataByte, err = ioutil.ReadFile(testParseLmstatServerUpWin)
+	dataByte, err = os.ReadFile(testParseLmstatServerUp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestParseLmstatLicenseInfoServer(t *testing.T) {
 func TestParseLmstatLicenseInfoVendor(t *testing.T) {
 	t.Parallel()
 
-	dataByte, err := ioutil.ReadFile(testParseLmstatLicenseInfo1)
+	dataByte, err := os.ReadFile(testParseLmstatLicenseInfo1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestParseLmstatLicenseInfoVendor(t *testing.T) {
 func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 	t.Parallel()
 
-	dataByte, err := ioutil.ReadFile(testParseLmstatLicenseInfo1)
+	dataByte, err := os.ReadFile(testParseLmstatLicenseInfo1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/go-kit/log"
@@ -48,7 +48,7 @@ func Load(filename string, logger log.Logger) (Configuration, error) {
 	level.Info(logger).Log("msg", "Loading license config file:")
 	level.Info(logger).Log(" - ", filename)
 
-	bytes, err := ioutil.ReadFile(filepath.Clean(filename))
+	bytes, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return Configuration{}, fmt.Errorf("failed to read %s: %w", filename, err)
 	}
@@ -56,6 +56,7 @@ func Load(filename string, logger log.Logger) (Configuration, error) {
 	var c Configuration
 
 	err = yaml.Unmarshal(bytes, &c)
+
 	if err != nil {
 		level.Error(logger).Log("Couldn't load config file: ", err)
 		return c, err

--- a/flexlm_exporter.go
+++ b/flexlm_exporter.go
@@ -92,8 +92,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		level.Warn(h.logger).Log("msg", "Couldn't create filtered metrics handler:", "err", err)
 		w.WriteHeader(http.StatusBadRequest)
-		//nolint:errcheck
-		w.Write([]byte(fmt.Sprintf("Couldn't create filtered metrics handler: %s", err)))
+		fmt.Fprintf(w, "Couldn't create filtered metrics handler: %s", err)
 
 		return
 	}
@@ -207,7 +206,6 @@ func main() {
 
 	http.Handle(*metricsPath, newHandler(!*disableExporterMetrics, *configPath, *maxRequests, logger))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		//nolint:errcheck
 		w.Write([]byte(`<html>
 			<head><title>Node Exporter</title></head>
 			<body>

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.6.1
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/text v0.3.6
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect


### PR DESCRIPTION
This add go1.18.x to the test matrix and deprecates go1.16.x