### PR TITLE
CircleCI: Update container registry to the new cimg ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: circleci/golang:1.18
+    - image: cimg/go:1.18
     parameters:
       working_dir:
         type: string
@@ -14,7 +14,7 @@ executors:
     working_directory: /go/src/github.com/mjtrangoni/flexlm_exporter
   python:
     docker:
-    - image: circleci/python
+    - image: cimg/python:3.10.4
 
 jobs:
   codespell:
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - checkout
-    - run: sudo pip install codespell
+    - run: pip3 install codespell
     - run: codespell --skip=".git,./vendor"
 
   build:
@@ -34,19 +34,6 @@ jobs:
     steps:
       # checkout the project
       - checkout
-      # Docker
-      - setup_remote_docker
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="20.10.14"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            ls -la /tmp/docker
-            sudo mv /tmp/docker/* /usr/bin/
-            docker --version
-            docker info
       # make and test
       - run:
           name: Binary Build
@@ -78,7 +65,7 @@ jobs:
       - run:
           name: Release binaries
           command: |
-            go install github.com/prometheus/promu
+            go install github.com/prometheus/promu@v0.13.0
             curl -sL https://git.io/goreleaser | bash
 
 workflows:

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
-    # Whenever the Go version is updated here, .github/workflows/build.yml and
-    # .circleci/config.yml should also be updated.
+    # Whenever the Go version is updated here, go.mod, .github/workflows/build.yml,
+    # and .circleci/config.yml should also be updated.
     version: 1.18
     cgo: false
 repository:

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,39 @@
 module github.com/mjtrangoni/flexlm_exporter
 
-go 1.15
+go 1.17
 
 require (
 	github.com/go-kit/log v0.1.0
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.30.0
 	github.com/prometheus/exporter-toolkit v0.6.1
-	github.com/stretchr/testify v1.7.0 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/text v0.3.6
-	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/go-logfmt/logfmt v0.5.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
+	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
This fixes CircleCI checks and container builds, as the old images were deprecated.

Thanks @knweiss for the go.mod hint!