### PR TITLE
added export for the user start time of a license usage

### DIFF
--- a/collector/lmstat_test.go
+++ b/collector/lmstat_test.go
@@ -331,3 +331,40 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 		t.Fatalf("Unexpected value for feature11: shouldn't match any reservation")
 	}
 }
+
+func TestParseLmstatLicenseInfoUserSince(t *testing.T) {
+	t.Parallel()
+
+	dataByte, err := os.ReadFile(testParseLmstatLicenseInfo1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataStr, err := splitOutput(dataByte)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, licUsersByFeature, _ := parseLmstatLicenseInfoFeature(dataStr, log.NewNopLogger())
+
+	const (
+		sinceUser1  = "Fri 10/20 14:12"
+		sinceUser17 = "Fri 10/20 12:36"
+	)
+
+	for username, licused := range licUsersByFeature["feature34"] {
+		for i := range licused {
+			if username == "user1" {
+				if licused[i].since != sinceUser1 {
+					t.Fatalf("Unexpected values for feature34[%s]: %s!=%s",
+						username, licused[i].since, sinceUser1)
+				}
+			} else if username == "user17" {
+				if licused[i].since != sinceUser17 {
+					t.Fatalf("Unexpected values for feature34[%s]: %s!=%s",
+						username, licused[i].since, sinceUser17)
+				}
+			}
+		}
+	}
+}

--- a/collector/regexp.go
+++ b/collector/regexp.go
@@ -18,11 +18,11 @@ var (
 			`Total of (?P<used>\d+) \w+ in use\)$`)
 	lmutilLicenseFeatureUsageUserRegex = regexp.MustCompile(
 		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ [[:print:]]+ (?P<ver>\(v[\w\.]+\)) \([\w\-\.]+\/\d+ ` +
-			`\d+\)\, start \w+ \d+\/\d+ \d+\:\d+(\,\s(?P<licenses>\d+)\s\w+|)` +
+			`\d+\)\, start (?P<since>\w+ \d+\/\d+ \d+\:\d+)(\,\s(?P<licenses>\d+)\s\w+|)` +
 			`(\s+\(linger\:\s\d+\s\/\s\d+\))?$`)
 	lmutilLicenseFeatureUsageUser2Regex = regexp.MustCompile(
 		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ (?P<ver>\(v[\w\.]+\)) \([\w\-\.]+\/\d+ ` +
-			`\d+\)\, start \w+ \d+\/\d+ \d+\:\d+(\,\s(?P<licenses>\d+)\s\w+|)` +
+			`\d+\)\, start (?P<since>\w+ \d+\/\d+ \d+\:\d+)(\,\s(?P<licenses>\d+)\s\w+|)` +
 			`(\s+\(linger\:\s\d+\s\/\s\d+\))?$`)
 	lmutilLicenseFeatureGroupReservRegex = regexp.MustCompile(
 		`^(\s+|)(?P<reservation>\d+)\s+\w+\s+for\s+(HOST_GROUP|GROUP)\s+` +

--- a/collector/structs.go
+++ b/collector/structs.go
@@ -41,6 +41,7 @@ type feature struct {
 type featureUserUsed struct {
 	num     float64
 	version string
+	since   string
 }
 
 type featureExp struct {


### PR DESCRIPTION
I added the export of the `Start time` of a usage for a license. This information is returned from lmstat, but was not exported to prometheus. I added it as the field `since` for the feature `flexlm_feature_used_users`. 

Maybe this information is of interest for other users, so feel free to merge the PR if you agree that this feature is useful. 

I also changed the way the named regex groups are used. Actually the named groups were still accessed by index, so I changed it, because I think it is more stable when a developer adds a new capture group to a regex, like i did now