### PR TITLE
update invalid exporter name

### DIFF
--- a/flexlm_exporter.go
+++ b/flexlm_exporter.go
@@ -206,9 +206,9 @@ func main() {
 	http.Handle(*metricsPath, newHandler(!*disableExporterMetrics, *configPath, *maxRequests, logger))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
-			<head><title>Node Exporter</title></head>
+			<head><title>FLEXlm Exporter</title></head>
 			<body>
-			<h1>Node Exporter</h1>
+			<h1>FLEXlm Exporter</h1>
 			<p><a href="` + *metricsPath + `">Metrics</a></p>
 			</body>
 			</html>`))


### PR DESCRIPTION
Probably an oversight on the landing page of the http server.