### PR TITLE
flags: Fix wrong kingpin library which removed path.lmutil

### DIFF
--- a/collector/paths.go
+++ b/collector/paths.go
@@ -15,7 +15,7 @@
 package collector
 
 import (
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "github.com/alecthomas/kingpin/v2"
 )
 
 // The path of the Flexlm binaries.


### PR DESCRIPTION
This was a trivial module mix, which ended up with a missing flag.

Fixes #77.

