### PR TITLE
Force server FQDN to lowercase, for handling windows output gracefully.

### DIFF
--- a/collector/fixtures/lmstat_server_up_win.txt
+++ b/collector/fixtures/lmstat_server_up_win.txt
@@ -5,6 +5,7 @@ License server status: 7788@BVS15004
     License file(s) on BVS15004: licensing\license.dat:
 
   BVS15004: license server UP (MASTER) v11.12
+  bvs15004: license server UP v11.12
 
 Vendor daemon status (on BVS15004):
 

--- a/collector/lmstat.go
+++ b/collector/lmstat.go
@@ -223,19 +223,19 @@ func parseLmstatLicenseInfoServer(outStr [][]string) map[string]*server {
 		if lmutilLicenseServersRegex.MatchString(lineJoined) {
 			matches := lmutilLicenseServersRegex.FindStringSubmatch(lineJoined)[1]
 			for _, portServer := range strings.Split(matches, ",") {
-				fqdn := strings.Split(portServer, "@")[1]
+				fqdn := strings.ToLower(strings.Split(portServer, "@")[1])
 				servers[strings.Split(fqdn, ".")[0]] = &server{
 					fqdn: fqdn, port: strings.Split(portServer, "@")[0],
 				}
 			}
 		} else if lmutilLicenseServerStatusRegex.MatchString(lineJoined) {
 			matches := lmutilLicenseServerStatusRegex.FindStringSubmatch(lineJoined)
-			servers[strings.Split(matches[1], ".")[0]].version = matches[4]
+			servers[strings.ToLower(strings.Split(matches[1], ".")[0])].version = matches[4]
 			if matches[2] == upString {
-				servers[strings.Split(matches[1], ".")[0]].status = true
+				servers[strings.ToLower(strings.Split(matches[1], ".")[0])].status = true
 			}
 			if matches[3] == " (MASTER)" {
-				servers[strings.Split(matches[1], ".")[0]].master = true
+				servers[strings.ToLower(strings.Split(matches[1], ".")[0])].master = true
 			}
 		}
 	}

--- a/collector/lmstat_test.go
+++ b/collector/lmstat_test.go
@@ -163,7 +163,7 @@ func TestParseLmstatLicenseInfoServer(t *testing.T) {
 
 	servers = parseLmstatLicenseInfoServer(dataStr)
 	for _, info := range servers {
-		if info.fqdn != "BVS15004" || info.version != "v11.12" ||
+		if info.fqdn != "bvs15004" || info.version != "v11.12" ||
 			!info.master || !info.status {
 			t.Fatalf("Unexpected values for %s: %s, %t, %t",
 				info.fqdn, info.version, info.master, info.status)


### PR DESCRIPTION
Extend fixture test case as well.

See,
```
--- FAIL: TestParseLmstatLicenseInfoServer (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x102cb46d4]

goroutine 38 [running]:
testing.tRunner.func1.2({0x102dcd700, 0x10311b520})
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1545 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1548 +0x360
panic({0x102dcd700?, 0x10311b520?})
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/runtime/panic.go:914 +0x218
github.com/mjtrangoni/flexlm_exporter/collector.parseLmstatLicenseInfoServer({0x140000de300, 0x10, 0x200?})
        /Users/mtrangoni/git/flexlm_exporter.git/collector/lmstat.go:233 +0x1e4
github.com/mjtrangoni/flexlm_exporter/collector.TestParseLmstatLicenseInfoServer(0x140002151e0)
        /Users/mtrangoni/git/flexlm_exporter.git/collector/lmstat_test.go:164 +0x844
testing.tRunner(0x140002151e0, 0x102e45fc0)
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.21.4/libexec/src/testing/testing.go:1648 +0x33c
FAIL    github.com/mjtrangoni/flexlm_exporter/collector 0.343s
```

@cloudrck cloud please test this branch, and let know if this solve your issue? #80.

Please also check if you see any uppercase server name label in your metrics. It would indicate that something else needs to be lowered. 

Thank you!