### PR TITLE
RESERVATION for HOST

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,15 @@
 run:
   modules-download-mode: mod
 linters-settings:
+  dogsled:
+    # Checks assignments with too many blank identifiers.
+    # Default: 2
+    max-blank-identifiers: 3
   funlen:
     lines: 300
     statements: 300
   gocyclo:
-    min-complexity: 40
+    min-complexity: 50
   dupl:
     threshold: 150
   depguard:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ changelog:
 archives:
   - name_template: >-
       {{ .ProjectName }}_
-      {{ title .Os }}_
+      {{ .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}

--- a/collector/fixtures/lmstat_app1.txt
+++ b/collector/fixtures/lmstat_app1.txt
@@ -19,6 +19,8 @@ Users of feature1:  (Total of 1814 licenses issued;  Total of 1206 licenses in u
   "feature0" v61.9, vendor: VENDOR1
   floating license
 
+	1 RESERVATION for HOST HOSTPC11 (host3.domain.net/27002)
+	10 RESERVATIONs for HOST HOSTPC12 (host3.domain.net/27002)
 	48 RESERVATIONs for GROUP GROUP1 (host3.domain.net/27002)
 	8 RESERVATIONs for GROUP GROUP2 (host3.domain.net/27002)
 	8 RESERVATIONs for GROUP GROUP3 (host3.domain.net/27002)

--- a/collector/lmstat.go
+++ b/collector/lmstat.go
@@ -369,11 +369,14 @@ func parseLmstatLicenseInfoFeature(outStr [][]string, logger log.Logger) (map[st
 			if reservHostByFeature[featureName] == nil {
 				reservHostByFeature[featureName] = map[string]float64{}
 			}
+
 			matches := lmutilLicenseFeatureHostReservRegex.FindStringSubmatch(lineJoined)
 			hostReserv, err := strconv.Atoi(matches[2])
+
 			if err != nil {
 				level.Error(logger).Log("could not convert", matches[1], "to integer:", err)
 			}
+
 			reservHostByFeature[featureName][matches[4]] = float64(hostReserv)
 		}
 	}

--- a/collector/lmstat_test.go
+++ b/collector/lmstat_test.go
@@ -210,7 +210,7 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	features, licUsersByFeature, reservGroupByFeature := parseLmstatLicenseInfoFeature(dataStr, log.NewNopLogger())
+	features, licUsersByFeature, reservGroupByFeature, reservHostByFeature := parseLmstatLicenseInfoFeature(dataStr, log.NewNopLogger())
 	for name, info := range features {
 		if name == "feature11" {
 			if info.issued != 16384 || info.used != 80 {
@@ -225,6 +225,7 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 	const (
 		licUsed1  = 1
 		licUsed8  = 8
+		licUsed10 = 10
 		licUsed12 = 12
 		licUsed16 = 16
 		licUsed26 = 26
@@ -329,6 +330,16 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 			}
 		}
 	}
+
+	for host, licreserv := range reservHostByFeature["feature0"] {
+		if host == "HOSTPC12" {
+			if licreserv != licUsed10 {
+				t.Fatalf("Unexpected values for feature0[%s]: %v!=10", host,
+					licreserv)
+			}
+		}
+	}
+
 	if reservGroupByFeature["feature11"] != nil {
 		t.Fatalf("Unexpected value for feature11: shouldn't match any reservation")
 	}
@@ -347,7 +358,7 @@ func TestParseLmstatLicenseInfoUserSince(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, licUsersByFeature, _ := parseLmstatLicenseInfoFeature(dataStr, log.NewNopLogger())
+	_, licUsersByFeature, _, _ := parseLmstatLicenseInfoFeature(dataStr, log.NewNopLogger())
 
 	// the year does not matter in this case, since lmstat omits the year information
 	ctime := time.Now()

--- a/collector/regexp.go
+++ b/collector/regexp.go
@@ -27,6 +27,9 @@ var (
 	lmutilLicenseFeatureGroupReservRegex = regexp.MustCompile(
 		`^(\s+|)(?P<reservation>\d+)\s+\w+\s+for\s+(HOST_GROUP|GROUP)\s+` +
 			`(?P<group>\w+).*$`)
+	lmutilLicenseFeatureHostReservRegex = regexp.MustCompile(
+		`^(\s+|)(?P<reservation>\d+)\s+\w+\s+for\s+(HOST)\s+` +
+			`(?P<host>\w+).*$`)
 	// lmutil lmstat -c port@hostname -i.
 	lmutilLicenseFeatureExpRegex = regexp.MustCompile(
 		`^(?P<feature>[[:graph:]]+)\s+(?P<version>[\d\.]+)\s+` +


### PR DESCRIPTION
This implements #84.

Now `RESERVATION for HOST` are going to be tracked via `flexlm_feature_reserved_host`.