### PR TITLE
circleci: Build with go1.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: cimg/go:1.22.6
+    - image: cimg/go:1.23.1
 
 jobs:
   codespell:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO                      ?= GO111MODULE=on go
 GOPATH                  := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU                   ?= $(GOPATH)/bin/promu
 GOLINTER                ?= $(GOPATH)/bin/golangci-lint
-GO_VERSION              ?= 1.22
+GO_VERSION              ?= 1.23
 pkgs                    = $(shell $(GO) list ./... | grep -v /vendor/)
 TARGET                  ?= flexlm_exporter
 DOCKER_IMAGE_NAME       ?= mjtrangoni/flexlm_exporter
@@ -94,4 +94,4 @@ crossbuild: promu
 $(GOPATH)/bin/golangci-lint lint:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
-		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.2
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0


### PR DESCRIPTION
CIrcleCI cimg/go:1.23 is now available