### PR TITLE
feature: added handling of queued licenses 

### DIFF
--- a/collector/fixtures/lmstat_app1.txt
+++ b/collector/fixtures/lmstat_app1.txt
@@ -102,7 +102,15 @@ Users of feature3:  (Total of 10 licenses issued;  Total of 0 licenses in use)
 
 Users of feature4:  (Total of 10 licenses issued;  Total of 0 licenses in use)
 
-Users of feature5:  (Total of 10 licenses issued;  Total of 0 licenses in use)
+Users of feature5:  (Total of 2 licenses issued;  Total of 2 licenses in use)
+
+  "feature5" v2017.12, vendor: vendor1
+  floating license
+
+    user3 server6u065 serverrrr (v2017.06) (host3.domain.net/27002 11101), start Mon 10/16 15:04
+    user3 server6u065 f2jf4_f2_ (v2017.06) (host3.domain.net/27002 14603), start Mon 10/16 15:52
+    user3 server6u065 fj209fj0 2017.06 (v2017.06) (host3.domain.net/27002 15480) queued for 1 license
+    user3 server6u065 f2jf4_f2_ 2017.06 (v2017.06) (host3.domain.net/27002 15480) queued for 1 license
 
 Users of feature6:  (Total of 1814 licenses issued;  Total of 0 licenses in use)
 

--- a/collector/lmstat.go
+++ b/collector/lmstat.go
@@ -364,7 +364,7 @@ func parseLmstatLicenseInfoFeature(outStr [][]string, logger *slog.Logger) (feat
 			//   * At least one such "used" line appears before any queued line
 			//     for that feature.
 			//
-			// This means the summary case above has already initialised
+			// This means the summary case above has already initialized
 			// features[featureName] with the "in use" count, so we only need to
 			// add the queued licenses on top of that here.
 			if licUsersByFeature[featureName] == nil {

--- a/collector/lmstat.go
+++ b/collector/lmstat.go
@@ -353,6 +353,64 @@ func parseLmstatLicenseInfoFeature(outStr [][]string, logger *slog.Logger) (feat
 					}
 				}
 			}
+		case lmutilLicenseFeatureUsageUserQueuedRegex.MatchString(lineJoined):
+			// Queued license lines look like regular user lines but end with
+			// "queued for N license" instead of a "start" timestamp. We only
+			// care about the username, feature version and queued count here.
+			//
+			// Assumptions for simplicity:
+			//   * Every feature with queued licenses also has at least one
+			//     non-queued "used" license line.
+			//   * At least one such "used" line appears before any queued line
+			//     for that feature.
+			//
+			// This means the summary case above has already initialised
+			// features[featureName] with the "in use" count, so we only need to
+			// add the queued licenses on top of that here.
+			if licUsersByFeature[featureName] == nil {
+				licUsersByFeature[featureName] = map[string][]*featureUserUsed{}
+			}
+
+			matches := reSubMatchMap(lmutilLicenseFeatureUsageUserQueuedRegex, lineJoined)
+			username := matches["user"]
+
+			if matches["ver"] != "" {
+				var found = -1
+
+				for i := range licUsersByFeature[featureName][username] {
+					if licUsersByFeature[featureName][username][i].version == matches["ver"] {
+						found = i
+					}
+				}
+
+				if found < 0 {
+					// Queued entries do not provide a start time; use a synthetic
+					// "since" value so queued licenses are still visible in
+					// flexlm_feature_used_users while keeping the label set stable.
+					sinceString := strconv.FormatInt(time.Now().Unix(), 10)
+					licUsersByFeature[featureName][username] = append(
+						licUsersByFeature[featureName][username],
+						&featureUserUsed{num: 0, version: matches["ver"], since: sinceString})
+				}
+			}
+
+			if matches["licenses"] != "" {
+				licQueued, err := strconv.Atoi(matches["licenses"])
+				if err != nil {
+					logger.Error("err", "could not convert", matches["licenses"], "to integer:", err)
+				}
+
+				for i := range licUsersByFeature[featureName][username] {
+					if licUsersByFeature[featureName][username][i].version == matches["ver"] {
+						licUsersByFeature[featureName][username][i].num += float64(licQueued)
+					}
+				}
+
+				// Add queued licenses on top of the "in use" count so that
+				// flexlm_feature_used can exceed flexlm_feature_issued when the
+				// server is overloaded.
+				features[featureName].used += float64(licQueued)
+			}
 		case lmutilLicenseFeatureGroupReservRegex.MatchString(lineJoined):
 			if reservGroupByFeature[featureName] == nil {
 				reservGroupByFeature[featureName] = map[string]float64{}

--- a/collector/lmstat_test.go
+++ b/collector/lmstat_test.go
@@ -217,12 +217,13 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 	features, licUsersByFeature, reservGroupByFeature, reservHostByFeature := parseLmstatLicenseInfoFeature(dataStr, logger)
 
 	for name, info := range features {
-		if name == "feature11" {
+		switch name {
+		case "feature11":
 			if info.issued != 16384 || info.used != 80 {
 				t.Fatalf("Unexpected values for %s: %v!=16384 %v!=80", name,
 					info.issued, info.used)
 			}
-		} else if name == "feature5" {
+		case "feature5":
 			// feature5 in the fixture has 2 licenses in use and 2 queued. The
 			// queued licenses are added on top of the "in use" count so that
 			// flexlm_feature_used can exceed flexlm_feature_issued when the

--- a/collector/lmstat_test.go
+++ b/collector/lmstat_test.go
@@ -222,6 +222,15 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 				t.Fatalf("Unexpected values for %s: %v!=16384 %v!=80", name,
 					info.issued, info.used)
 			}
+		} else if name == "feature5" {
+			// feature5 in the fixture has 2 licenses in use and 2 queued. The
+			// queued licenses are added on top of the "in use" count so that
+			// flexlm_feature_used can exceed flexlm_feature_issued when the
+			// server is overloaded. Therefore we expect used == 4 here.
+			if info.issued != 2 || info.used != 4 {
+				t.Fatalf("Unexpected values for %s: %v!=2 %v!=4", name,
+					info.issued, info.used)
+			}
 		}
 	}
 
@@ -235,6 +244,21 @@ func TestParseLmstatLicenseInfoFeature(t *testing.T) {
 		licUsed16 = 16
 		licUsed26 = 26
 	)
+
+	// For feature5 in the fixture, user3 has 2 active checkouts and 2 queued
+	// requests, each for a single license. The parser adds queued licenses to
+	// the same per-user counters that back flexlm_feature_used_users, so we
+	// expect user3's total usage to be 4 licenses.
+	for username, licused := range licUsersByFeature["feature5"] {
+		for i := range licused {
+			if username == "user3" {
+				if licused[i].num != 4 {
+					t.Fatalf("Unexpected values for feature5[%s]: %v!=4",
+						username, licused[i].num)
+				}
+			}
+		}
+	}
 
 	for username, licused := range licUsersByFeature["feature34"] {
 		for i := range licused {

--- a/collector/regexp.go
+++ b/collector/regexp.go
@@ -25,6 +25,9 @@ var (
 		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ (?P<ver>\(v[\w\.]+\)) \([\w\-\.]+\/\d+ ` +
 			`\d+\)\, start (?P<since>\w+ \d+\/\d+ \d+\:\d+)(\,\s(?P<licenses>\d+)\s\w+|)` +
 			`(\s+\(linger\:\s\d+\s\/\s\d+\))?$`)
+	lmutilLicenseFeatureUsageUserQueuedRegex = regexp.MustCompile(
+		`^\s+(?P<user>[\w[:print:]]+) [\w\-\.]+ [[:print:]]+ [0-9.]+ (?P<ver>\(v[\w\.]+\)) \([\w\-\.]+\/\d+ ` +
+			`\d+\)\s+queued for (?P<licenses>\d+) license[s]?$`)
 	lmutilLicenseFeatureGroupReservRegex = regexp.MustCompile(
 		`^(\s+|)(?P<reservation>\d+)\s+\w+\s+for\s+(HOST_GROUP|GROUP)\s+` +
 			`(?P<group>\w+).*$`)


### PR DESCRIPTION
Queued licenses are added directly onto flexlm_feature_used and flexlm_feature_used_users, allowing utilization of issued licenses to exceed 100% for flagging with alerts.

lmstat_test.go and lmstat_app1.txt fixture updated to test new case in lmstat.go.