### PR TITLE
 update lmstat command to use -a -i for lmstat_feature_exp

### DIFF
--- a/collector/lmstat_feature_exp.go
+++ b/collector/lmstat_feature_exp.go
@@ -184,16 +184,15 @@ func (c *lmstatFeatureExpCollector) collect(licenses *config.License, ch chan<- 
 		err      error
 	)
 	// Call lmstat with -i (lmstat -i does not give information from the server,
-	// but only reads the license file)
-
+	// but only reads the license file) (actually -a is needed)
 	switch {
 	case licenses.LicenseFile != "":
-		outBytes, err = lmutilOutput(c.logger, "lmstat", "-c", licenses.LicenseFile, "-i")
+		outBytes, err = lmutilOutput(c.logger, "lmstat", "-c", licenses.LicenseFile, "-a", "-i")
 		if err != nil {
 			return err
 		}
 	case licenses.LicenseServer != "":
-		outBytes, err = lmutilOutput(c.logger, "lmstat", "-c", licenses.LicenseServer, "-i")
+		outBytes, err = lmutilOutput(c.logger, "lmstat", "-c", licenses.LicenseServer, "-a", "-i")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This addresses issue #83 .  The toonboom license daemon returns an empty result when `lmstat -i` is used without `-a`.  `lmstat -a -i` returns expiry info (along with usage info, which is ignored by the lmstat_feature_exp parser.  