### PR TITLE
Standardize permanent license expiration to +Inf and update Dockerfile base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,24 @@
-FROM docker.io/rockylinux/rockylinux:8
-LABEL maintainer="Mario Trangoni <mjtrangoni@gmail.com>"
+FROM docker.io/rockylinux/rockylinux:9.3-minimal
+
+LABEL maintainer="Mario Trangoni mjtrangoni@gmail.com"
 LABEL org.opencontainers.image.source="https://github.com/mjtrangoni/flexlm_exporter"
 
-# Install dependencies and clean cache
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial && \
-    dnf -y update && \
-    dnf -y install bash-completion redhat-lsb-core strace && \
-    dnf -y clean all && \
-    rm -f /etc/pki/tls/private/postfix.key
+ENV HOME=/home/exporter
+
+RUN microdnf -y update &&
+microdnf -y install shadow-utils bash-completion strace glibc &&
+microdnf -y clean all &&
+ln -s /lib64/ld-linux-x86-64.so.2 /lib64/ld-lsb-x86-64.so.3 &&
+groupadd -g 30001 exporter &&
+useradd --no-log-init -m -d /home/exporter -u 30001 -g 30001 exporter &&
+mkdir -p /home/exporter/config &&
+chown -R exporter:exporter /home/exporter/config
 
 COPY flexlm_exporter /bin/flexlm_exporter
 
-# Add exporter user and group
-RUN groupadd -g 30001 exporter && \
-  useradd --no-log-init -m -d /home/exporter -u 30001 -g 30001 exporter
+WORKDIR /home/exporter
+USER exporter
 
-EXPOSE      9319
-USER        exporter
-WORKDIR     /home/exporter
+EXPOSE 9319
 
-RUN mkdir -p /home/exporter/config &&\
-  chown -R 30001:30001 /home/exporter/config
-
-# Default home dir
-ENV HOME=/home/exporter
-
-ENTRYPOINT  [ "/bin/flexlm_exporter" ]
+ENTRYPOINT [ "/bin/flexlm_exporter" ]

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Metrics will now be reachable at <http://localhost:9319/metrics>.
 ## What's exported?
 
  1. `lmutil lmstat -v` information.
- 1. `lmutil lmstat -c license_file -a` or `lmutil lmstat -c license_server -a`
-   license information.
- 1. `lmutil lmstat -c license_file -i` or `lmutil lmstat -c license_server -i`
-   license features expiration date.
+ 2. `lmutil lmstat -c license_file -a` or `lmutil lmstat -c license_server -a`
+   license information. This includes the `licenseType` label to distinguish between `floating` and `node-locked` licenses.
+ 3. `lmutil lmstat -c license_file -i` or `lmutil lmstat -c license_server -i`
+   license features expiration date. Permanent licenses (e.g. `01-jan-0000`, `01-jan-2099` or `permanent`) are exported as `+Inf`.
 
 ## Dashboards
 

--- a/collector/fixtures/lmstat_i_app1.txt
+++ b/collector/fixtures/lmstat_i_app1.txt
@@ -21,3 +21,4 @@ feature13                       2018.09      2           30-sep-2018  vendor2
 feature14                       2018.09      2           30-sep-2018  vendor2
 feature15                       2018.09      2           1-jan-0      vendor2
 feature16                       0.1          1           01-jan-0000  vendor2
+feature17                       0.1          1           01-jan-2099  vendor2

--- a/collector/lmstat_feature_exp.go
+++ b/collector/lmstat_feature_exp.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	lenghtOne   = 1
-	posInfinity = 1
-	yearLength  = 4
+	lenghtOne       = 1
+	posInfinity     = 1
+	datePartsLength = 3
+	yearLength      = 4
 )
 
 type lmstatFeatureExpCollector struct {
@@ -109,7 +110,7 @@ func parseLmstatLicenseFeatureExpDate(outStr [][]string, logger *slog.Logger) ma
 		logger.Debug("debug", "matches", matches)
 		// Parse date, month has to be capitalized.
 		slice := strings.Split(matches[expIndex], "-")
-		if len(slice) >= 3 {
+		if len(slice) >= datePartsLength {
 			day, month, year := slice[0], slice[1], slice[2]
 			if len(year) > yearLength {
 				lenToRemove := len(year) - yearLength

--- a/collector/lmstat_feature_exp.go
+++ b/collector/lmstat_feature_exp.go
@@ -109,7 +109,7 @@ func parseLmstatLicenseFeatureExpDate(outStr [][]string, logger *slog.Logger) ma
 		logger.Debug("debug", "matches", matches)
 		// Parse date, month has to be capitalized.
 		slice := strings.Split(matches[expIndex], "-")
-		if len(slice) > lenghtOne {
+		if len(slice) >= 3 {
 			day, month, year := slice[0], slice[1], slice[2]
 			if len(year) > yearLength {
 				lenToRemove := len(year) - yearLength
@@ -131,7 +131,7 @@ func parseLmstatLicenseFeatureExpDate(outStr [][]string, logger *slog.Logger) ma
 				logger.Error("err", "could not convert to date:", err)
 			}
 
-			if expireDate.Unix() <= 0 {
+			if expireDate.Unix() <= 0 || year == "2099" {
 				expires = math.Inf(posInfinity)
 			} else {
 				expires = float64(expireDate.Unix())

--- a/collector/lmstat_feature_exp_test.go
+++ b/collector/lmstat_feature_exp_test.go
@@ -99,13 +99,23 @@ func TestParseLmstatLicenseFeatureExpDate1(t *testing.T) {
 					feature.licenses, feature.vendor,
 					feature.expires)
 			}
+		case feature.name == "feature17":
+			if feature.version != "0.1" ||
+				feature.licenses != "1" ||
+				feature.expires != math.Inf(posInfinity) ||
+				feature.vendor != vendor2String {
+				t.Fatalf("Unexpected values %s, %s, %s, %s, != %f",
+					feature.name, feature.version,
+					feature.licenses, feature.vendor,
+					feature.expires)
+			}
 
 			found = true
 		}
 	}
 
 	if !found {
-		t.Fatalf("feature16 not found")
+		t.Fatalf("feature17 not found")
 	}
 }
 


### PR DESCRIPTION
Hi Mario,

Thanks for merging PR #212!

As discussed, I have made the following updates:
- **Dates Standardization**: Standardized all variations of permanent licenses (including Matlab's `01-jan-2099`, `01-jan-0000`, and `permanent(no expiration date)`) to consistently export as `+Inf`. This makes it fully coherent and prevents false positive alerts. In Grafana, users can simply map `+Inf` to "Permanent" using Value Mappings.
- **README**: Updated the `README.md` to document the `licenseType` label from PR #212 and the new `+Inf` date standardization.

Feel free to edit the PR as needed (maintainer edits are allowed). Since there are quite a few nice features added recently, maybe we could cut a new release soon?

Best,
Manea
